### PR TITLE
bump Uptime Kuma to version 1.18.4

### DIFF
--- a/uptime-kuma/Dockerfile
+++ b/uptime-kuma/Dockerfile
@@ -28,7 +28,7 @@ RUN \
     && npm config set unsafe-perm true \
     \
     && mkdir -p /opt/uptime-kuma \
-    && curl -L -s "https://github.com/louislam/uptime-kuma/archive/refs/tags/1.18.0.tar.gz" \
+    && curl -L -s "https://github.com/louislam/uptime-kuma/archive/refs/tags/1.18.4.tar.gz" \
         | tar zxvf - --strip-components 1 -C /opt/uptime-kuma \
     \
     && cd /opt/uptime-kuma \


### PR DESCRIPTION
# Proposed Changes

Update packaged version of Uptime Kuma to the latest version (1.18.4)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
