### PR TITLE
Fix: Determine  port for discovery from addon config

### DIFF
--- a/uptime-kuma/rootfs/etc/s6-overlay/s6-rc.d/discovery/run
+++ b/uptime-kuma/rootfs/etc/s6-overlay/s6-rc.d/discovery/run
@@ -10,7 +10,7 @@ declare config
 bashio::net.wait_for 3001 127.0.0.1 300
 
 config=$(bashio::var.json \
-    url "http://$(hostname):$(bashio::addon.port 3001)"
+    url "http://$(hostname):3001"
 )
 
 if bashio::discovery "uptime_kuma" "${config}" > /dev/null; then


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The port used for URL in discovery message is now determined from addon config if possible instead of using the default port. Updated also a stale comment

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected script comment to reference Uptime Kuma instead of AdGuard Home.
  * Fixed discovery target to use the runtime-determined host and port rather than a hard-coded address.

* **Improvements**
  * Clarified discovery log messages with corrected success/error wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->