### PR TITLE
Drop support for armv7 systems

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,7 @@
       "matchStringsStrategy": "any",
       "matchStrings": [
         "ARG BUILD_FROM=(?<depName>.*?):(?<currentValue>.*?)\\s+",
-        "(aarch64|amd64|armhf|armv7|i386):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
+        "(aarch64|amd64):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
       ],
       "datasourceTemplate": "docker"
     },

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armhf Architecture][armhf-shield]
-![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 [![Github Actions][github-actions-shield]][github-actions]
 ![Project Maintenance][maintenance-shield]
@@ -99,8 +96,6 @@ SOFTWARE.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/addon-uptime-kuma.svg
 [commits]: https://github.com/hassio-addons/addon-uptime-kuma/commits/master
 [contributors]: https://github.com/hassio-addons/addon-uptime-kuma/graphs/contributors
@@ -115,7 +110,6 @@ SOFTWARE.
 [github-actions]: https://github.com/hassio-addons/addon-uptime-kuma/actions
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
-[i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/hassio-addons/addon-uptime-kuma/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/addon-uptime-kuma.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg

--- a/uptime-kuma/Dockerfile
+++ b/uptime-kuma/Dockerfile
@@ -44,8 +44,7 @@ RUN \
     && npm run download-dist \
     \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then CLOUDFLARED_ARCH="arm64"; \
-    elif [ "${BUILD_ARCH}" = "amd64" ]; then CLOUDFLARED_ARCH="amd64"; \
-    elif [ "${BUILD_ARCH}" = "armv7" ]; then CLOUDFLARED_ARCH="arm"; fi \
+    elif [ "${BUILD_ARCH}" = "amd64" ]; then CLOUDFLARED_ARCH="amd64"; fi \
     && curl -L --fail -o /usr/bin/cloudflared \
         "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-${CLOUDFLARED_ARCH}" \
     && chmod +x /usr/bin/cloudflared \

--- a/uptime-kuma/build.yaml
+++ b/uptime-kuma/build.yaml
@@ -2,4 +2,3 @@
 build_from:
   aarch64: ghcr.io/hassio-addons/base:18.2.1
   amd64: ghcr.io/hassio-addons/base:18.2.1
-  armv7: ghcr.io/hassio-addons/base:18.2.1

--- a/uptime-kuma/config.yaml
+++ b/uptime-kuma/config.yaml
@@ -9,7 +9,6 @@ init: false
 arch:
   - aarch64
   - amd64
-  - armv7
 ports:
   3001/tcp: 3001
 ports_description:


### PR DESCRIPTION
# Proposed Changes

The Home Assistant project is dropping support for the armv7 architecture in December. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed support for 32-bit and legacy ARM processor architectures (armv7, armhf, i386); application now exclusively supports aarch64 and amd64.
  * Updated documentation and build configuration to reflect supported architecture changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->