### PR TITLE
⬆️ Upgrade to base image 21.0.0 (Alpine 3.24)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,10 +9,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "//Dockerfile$/",
-        "//build.yaml$/"
-      ],
+      "managerFilePatterns": ["//Dockerfile$/", "//build.yaml$/"],
       "matchStringsStrategy": "any",
       "matchStrings": [
         "ARG BUILD_FROM=(?<depName>.*?):(?<currentValue>.*?)\\s+",
@@ -22,9 +19,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "//Dockerfile$/"
-      ],
+      "managerFilePatterns": ["//Dockerfile$/"],
       "matchStringsStrategy": "any",
       "matchStrings": [
         "\\s\\s(?<package>[a-z0-9][a-z0-9-]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
@@ -35,9 +30,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "//Dockerfile$/"
-      ],
+      "managerFilePatterns": ["//Dockerfile$/"],
       "matchStrings": [
         "ARG UPTIME_KUMA_VERSION=[\"']?(?<currentValue>.+?)[\"']?\\s+"
       ],
@@ -46,9 +39,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "//Dockerfile$/"
-      ],
+      "managerFilePatterns": ["//Dockerfile$/"],
       "matchStrings": [
         "ARG CLOUDFLARED_VERSION=[\"']?(?<currentValue>.+?)[\"']?\\s+"
       ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,7 +26,7 @@
       ],
       "versioningTemplate": "loose",
       "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_23/{{package}}"
+      "depNameTemplate": "alpine_3_24/{{package}}"
     },
     {
       "customType": "regex",
@@ -51,7 +51,7 @@
   "packageRules": [
     {
       "matchDatasources": ["repology"],
-      "matchPackageNames": ["alpine_3_23/*"],
+      "matchPackageNames": ["alpine_3_24/*"],
       "versioning": "loose"
     },
     {

--- a/uptime-kuma/Dockerfile
+++ b/uptime-kuma/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:20.2.0
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:21.0.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -18,15 +18,15 @@ ARG BUILD_ARCH=amd64
 # hadolint ignore=DL3003,DL3042
 RUN \
     apk add --no-cache --virtual .build-dependencies \
-        build-base=0.5-r3 \
-        py3-pip=25.1.1-r1 \
+        build-base=0.5-r4 \
+        py3-pip=26.1.2-r0 \
     \
     && apk add --no-cache \
-        iputils=20250605-r0 \
-        nodejs=24.14.1-r0 \
-        npm=11.11.0-r0 \
-        python3=3.12.13-r0 \
-        setpriv=2.41.4-r0 \
+        iputils=20250605-r2 \
+        nodejs=24.16.0-r0 \
+        npm=11.12.1-r0 \
+        python3=3.14.5-r0 \
+        setpriv=2.42-r0 \
     \
     && mkdir -p /opt/uptime-kuma \
     && curl -L -s "https://github.com/louislam/uptime-kuma/archive/refs/tags/${UPTIME_KUMA_VERSION}.tar.gz" \

--- a/uptime-kuma/build.yaml
+++ b/uptime-kuma/build.yaml
@@ -1,4 +1,4 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base:20.2.0
-  amd64: ghcr.io/hassio-addons/base:20.2.0
+  aarch64: ghcr.io/hassio-addons/base:21.0.0
+  amd64: ghcr.io/hassio-addons/base:21.0.0


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Update the add-on to the latest Home Assistant add-on base image, `ghcr.io/hassio-addons/base:21.0.0`, which is based on Alpine Linux 3.24. All pinned `apk` packages are bumped to their latest versions for Alpine 3.24:

| package | from | to |
| --- | --- | --- |
| `build-base` | 0.5-r3 | 0.5-r4 |
| `py3-pip` | 25.1.1-r1 | 26.1.2-r0 |
| `iputils` | 20250605-r0 | 20250605-r2 |
| `nodejs` | 24.14.1-r0 | 24.16.0-r0 |
| `npm` | 11.11.0-r0 | 11.12.1-r0 |
| `python3` | 3.12.13-r0 | 3.14.5-r0 |
| `setpriv` | 2.41.4-r0 | 2.42-r0 |

The image builds successfully with `docker build . --progress=plain --no-cache`.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
