### PR TITLE
📝 Polish README and documentation wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Uptime Kuma is a self-hosted monitoring tool, comparable to "Uptime Robot".
 
 ## About
 
-Uptime Kuma is an open source monitoring tool, which can be best
+Uptime Kuma is an open-source monitoring tool, which is best
 compared to a self-hosted variant of a commercial service like "Uptime Robot".
 
 It enables you to monitor services over HTTP/S, TCP, DNS, and other protocols
@@ -103,7 +103,6 @@ SOFTWARE.
 [issue]: https://github.com/hassio-addons/app-uptime-kuma/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/app-uptime-kuma.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2026.svg
-[nodered-docs]: https://nodered.org/docs
 [patreon-shield]: https://frenck.dev/wp-content/uploads/2019/12/patreon.png
 [patreon]: https://www.patreon.com/frenck
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-production%20ready-brightgreen.svg

--- a/uptime-kuma/.README.j2
+++ b/uptime-kuma/.README.j2
@@ -6,11 +6,11 @@
 
 [![Support Frenck on Patreon][patreon-shield]][patreon]
 
-It is a self-hosted monitoring tool like "Uptime Robot".
+Uptime Kuma is a self-hosted monitoring tool, comparable to "Uptime Robot".
 
 ## About
 
-Uptime Kuma is an open source monitoring tool, which can be best
+Uptime Kuma is an open-source monitoring tool, which is best
 compared to a self-hosted variant of a commercial service like "Uptime Robot".
 
 It enables you to monitor services over HTTP/S, TCP, DNS, and other protocols

--- a/uptime-kuma/DOCS.md
+++ b/uptime-kuma/DOCS.md
@@ -1,6 +1,6 @@
 # Home Assistant Community App: Uptime Kuma
 
-Uptime Kuma is an open source monitoring tool, which can be best
+Uptime Kuma is an open-source monitoring tool, which is best
 compared to a self-hosted variant of a commercial service like "Uptime Robot".
 
 It enables you to monitor services over HTTP/S, TCP, DNS, and other protocols


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

A small documentation polish pass over the README, the README template, and the DOCS:

- Align the README template (`.README.j2`) intro line with the repository `README.md`, replacing the vague "It is a self-hosted monitoring tool..." opener with "Uptime Kuma is a self-hosted monitoring tool, comparable to "Uptime Robot".".
- Tighten the description wording to "open-source monitoring tool, which is best compared to..." across the README, README template, and DOCS.
- Remove a leftover, unused Node-RED documentation link reference (`[nodered-docs]`) from the README.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized terminology throughout documentation by updating "open source" to "open-source" for consistency.
  * Refined wording in About section descriptions across README and template files for improved clarity.
  * Removed an outdated reference link from documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->